### PR TITLE
Update create-unattended-iso.sh

### DIFF
--- a/create-unattended-iso.sh
+++ b/create-unattended-iso.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # file names & paths
-tmp="/tmp"  # destination folder to store the final iso file
+tmp="/home/$USER"  # destination folder to store the final iso file
 hostname="ubuntu"
 currentuser="$( whoami)"
 


### PR DESCRIPTION
All files in /tmp folder will be removed upon reboot. Saving the unattended iso in there is therefore not safe. The best place should be in /home/$USER/. Do change this accordingly to your needs.