### PR TITLE
output to $HOME instead of /home/$USER

### DIFF
--- a/create-unattended-iso.sh
+++ b/create-unattended-iso.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # file names & paths
-tmp="/home/$USER"  # destination folder to store the final iso file
+tmp="$HOME"  # destination folder to store the final iso file
 hostname="ubuntu"
 currentuser="$( whoami)"
 


### PR DESCRIPTION
if you run this from a root prompt, or as any other user whose home directory does not live at /home/$USER, it fails with the message "/home/root does not exist".  Using the $HOME variable will prevent it from failing when the users home directory does not live at the expected path.